### PR TITLE
gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 public/uploads/*
+
+config/secrets.yml


### PR DESCRIPTION
what
secrets.ymlをgitignore
why
gitの管理下から外す