### PR TITLE
サインアウトできない問題の解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ end
 gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog-aws'
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,10 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jquery-rails (4.3.3)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kgio (2.11.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -294,6 +298,7 @@ DEPENDENCIES
   font-awesome-rails
   haml-rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4, < 0.6.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,5 +11,7 @@
 // about supported directives.
 //
 
+//= require jquery
+//= require jquery_ujs
 //= require turbolinks
 //= require_tree .


### PR DESCRIPTION
# what
- gem jqueryの追加
- application.jsにrequireを2件追記
# why
jqueryがないとdeviseではサインアウトできないらしい
参考
https://qiita.com/yuskamiya/items/ee5280dfcbca9d7216ae
rails 5.1から jqueryが入らなくなった模様
https://blog.bigbinary.com/2017/06/20/rails-5-1-has-dropped-dependency-on-jquery-from-the-default-stack.html