### PR TITLE
carrierwave問題の一時的な作業ミスの解消

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,4 @@
 //= require bootstrap-sprockets
 //= require bootstrap-tagsinput.min
 //= require_tree .
+//= require ckeditor/init

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,8 +6,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [580, 300]
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  # storage :file
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:


### PR DESCRIPTION
作業用に記述を削除して作業していたものをそのままプッシュしてしまっていたためそれを解消