### PR TITLE
イメージ投稿詳細ページのアバター画像の修正

### DIFF
--- a/app/views/post_images/show.html.haml
+++ b/app/views/post_images/show.html.haml
@@ -36,8 +36,8 @@
     .contents__container
       .contents__container__top
         .contents__container__top__icon
-          - if current_user.avatar_image?
-            = image_tag current_user.avatar_image
+          - if @post_image.user.avatar_image?
+            = image_tag @post_image.user.avatar_image
           - else
             = fa_icon ("smile 2x")
         %ul


### PR DESCRIPTION
what
●イメージ投稿詳細ページのアバター画像がカレントユーザーのアバターイメージ表示
→イメージ投稿者のアバターイメージに変換されるよう変更
why
●バグ修正